### PR TITLE
Add default key feature to the configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,21 @@ Dynamic environment configurations will be loaded from `.env.config` file, and w
       }
     }
    ```
-3. Here, you have the flexible to override any environment variables through the direct environment variables. You can simply pass that variable during the application startup to override any values. For example:
+3. Use the `DEFAULT` to defined your environment variables which have same patterns across the environments. For example,
+    ```
+    CONTACT_US_EMAIL (DEV): hello-dev@abcd.com
+    CONTACT_US_EMAIL (STAG): hello-stag@abcd.com
+    CONTACT_US_EMAIL (PROD): hello@abcd.com
+    ```
+    Here, `DEV` and `STAG` environment variables have same pattern, and `PROD` differed from that pattern. So you can simply define,
+    ```json
+    { "CONTACT_US_EMAIL": {
+        "DEFAULT": "hello-{{ENV}}@abcd.com",
+        "PROD": "hello@abcd.com"
+      }
+    }
+    ```
+4. Here, you have the flexible to override any environment variables through the direct environment variables. You can simply pass that variable during the application startup to override any values. For example:
     ```json
     {
       "SERVER_URL": "{{BASE_URL}}/api/v1",

--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ Dynamic environment configurations will be loaded from `.env.config` file, and w
       }
     }
    ```
-3. Use the `DEFAULT` to defined your environment variables which have same patterns across the environments. For example,
+3. Use the `DEFAULT` to defined your environment variables that have the same patterns across the environments. For example,
     ```
     CONTACT_US_EMAIL (DEV): hello-dev@abcd.com
     CONTACT_US_EMAIL (STAG): hello-stag@abcd.com
     CONTACT_US_EMAIL (PROD): hello@abcd.com
     ```
-    Here, `DEV` and `STAG` environment variables have same pattern, and `PROD` differed from that pattern. So you can simply define,
+    Here, `DEV` and `STAG` environment variables have the same pattern, and `PROD` differed from that pattern. So you can simply define,
     ```json
     { "CONTACT_US_EMAIL": {
         "DEFAULT": "hello-{{ENV}}@abcd.com",

--- a/src/config.js
+++ b/src/config.js
@@ -73,7 +73,10 @@ function parseEnv(config) {
     const nodeEnv = getProcessEnv()["ENV"] || getProcessEnv()["NODE_ENV"] || "DEV_1";
     Object.keys(config).forEach(function (key) {
       if (typeof config[key] === 'object') {
-        const nodeEnvValue = config[key][nodeEnv];
+        let nodeEnvValue = config[key][nodeEnv];
+        if (!nodeEnvValue) {
+          nodeEnvValue = config[key]["default"] || config[key]["DEFAULT"];
+        }
         config[key] = nodeEnvValue;
       }
 

--- a/test/.env.config
+++ b/test/.env.config
@@ -12,5 +12,9 @@
     "PROD": "{{DB_PASSWORD}}"
   },
   "ANALYTICS_URL": "https://{{ENV}}-analytics.{{SYSTEM}}-albc.com",
-  "LOG_URL": "https://{{ENV}}-abc.{{ENV}}-service.log-man.com"
+  "LOG_URL": "https://{{ENV}}-abc.{{ENV}}-service.log-man.com",
+  "CONTACT_US_EMAIL": {
+   "DEFAULT": "hello-{{ENV}}@abcd.com",
+   "PROD": "hello@abcd.com"
+ }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -164,4 +164,32 @@ describe("should configure environment variables", () => {
     expect(response).haveOwnProperty("error");  
     getProcessEnvStub.restore();
   })
+
+  it("should pick the DEFAULT for un-defined environment configurations", () => {
+    let response = envOne.config()
+    expect(response).haveOwnProperty("CONTACT_US_EMAIL");
+    expect(mockGetProcessEnv.ENV).is.equal("DEV")
+    expect(response.CONTACT_US_EMAIL).is.not.null;
+    expect(response.CONTACT_US_EMAIL).is.equal("hello-DEV@abcd.com");
+
+    mockGetProcessEnv = { ENV: "STAG" }
+    getProcessEnvStub.restore(); // restore already wrapped function
+    getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
+    response = envOne.config()
+    expect(response).haveOwnProperty("CONTACT_US_EMAIL");
+    expect(mockGetProcessEnv.ENV).is.equal("STAG")
+    expect(response.CONTACT_US_EMAIL).is.not.null;
+    expect(response.CONTACT_US_EMAIL).is.equal("hello-STAG@abcd.com");
+
+    mockGetProcessEnv = { ENV: "PROD" }
+    getProcessEnvStub.restore(); // restore already wrapped function
+    getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
+    response = envOne.config()
+    expect(response).haveOwnProperty("CONTACT_US_EMAIL");
+    expect(mockGetProcessEnv.ENV).is.equal("PROD")
+    expect(response.CONTACT_US_EMAIL).is.not.null;
+    expect(response.CONTACT_US_EMAIL).is.not.equal("hello-PROD@abcd.com");
+    expect(response.CONTACT_US_EMAIL).is.equal("hello@abcd.com");
+    getProcessEnvStub.restore();
+  })
 });


### PR DESCRIPTION
Use the DEFAULT to defined your environment variables that have the same patterns across the environments. For example,
```
CONTACT_US_EMAIL (DEV): hello-dev@abcd.com
CONTACT_US_EMAIL (STAG): hello-stag@abcd.com
CONTACT_US_EMAIL (PROD): hello@abcd.com
```
Here, DEV and STAG environment variables have the same pattern, and PROD differed from that pattern. So you can simply define,
```
{ "CONTACT_US_EMAIL": {
    "DEFAULT": "hello-{{ENV}}@abcd.com",
    "PROD": "hello@abcd.com"
  }
}
```