### PR TITLE
Envone configured environment response object structure refactor

### DIFF
--- a/example/.env.config
+++ b/example/.env.config
@@ -2,28 +2,30 @@
   "BFF_URL": "{{BASE_URL}}/api/v1",
   "SALESFORCE_URL":"https://{{ENV}}-salesforce.com/v1/test",
   "AWS_ACCESS_KEY": {
-    "DEV": "w5Dty3EaFi983etw",
-    "STAG": "u7Awda72Sd2Wfaf",
-    "PROD": "{{AWS_KEY}}"
+    "dev": "w5Dty3EaFi983etw",
+    "stag": "u7Awda72Sd2Wfaf",
+    "prod": "{{AWS_KEY}}"
   },
   "AWS_ACCESS_SECRET": {
-    "DEV": "w5Dty3EaFi983etw",
-    "STAG": "{{AWS_SECRET}}",
-    "PROD": "{{AWS_SECRET}}"
+    "dev": "w5Dty3EaFi983etw",
+    "stag": "{{AWS_SECRET}}",
+    "prod": "{{AWS_SECRET}}",
+    "isSecret": true
   },
   "DB_CONNECTION_URL": "https://{{ENV}}-service-xyz-{{ENV}}.xyx.{{ENV}}-mongo.com",
   "DB_CONNECTION_PASSWORD": {
-    "DEV": "w5Dty3EaFi983etw",
-    "STAG": "{{DB_PASSWORD}}",
-    "PROD": "{{DB_PASSWORD}}"
+    "dev": "w5Dty3EaFi983etw",
+    "stag": "{{DB_PASSWORD}}",
+    "prod": "{{DB_PASSWORD}}",
+    "isSecret": true
   },
   "ANALYTICS_URL": {
-    "DEV": "https://analytics.dev-services.com/",
-    "STAG": "https://analytics.stag-services.com/",
-    "PROD": "https://analytics.prod-services.com/"
+    "dev": "https://analytics.dev-services.com/",
+    "stag": "https://analytics.stag-services.com/",
+    "prod": "https://analytics.prod-services.com/"
   },
   "CONTACT_US_EMAIL": {
-   "DEFAULT": "hello-{{ENV}}@abcd.com",
-   "PROD": "hello@abcd.com"
+   "default": "hello-{{ENV}}@abcd.com",
+   "prod": "hello@abcd.com"
   }
 }

--- a/example/README.md
+++ b/example/README.md
@@ -7,30 +7,32 @@
   "BFF_URL": "{{BASE_URL}}/api/v1",
   "SALESFORCE_URL":"https://{{ENV}}-salesforce.com/v1/test",
   "AWS_ACCESS_KEY": {
-    "DEV": "w5Dty3EaFi983etw",
-    "STAG": "u7Awda72Sd2Wfaf",
-    "PROD": "{{AWS_KEY}}"
+    "dev": "w5Dty3EaFi983etw",
+    "stag": "u7Awda72Sd2Wfaf",
+    "prod": "{{AWS_KEY}}"
   },
   "AWS_ACCESS_SECRET": {
-    "DEV": "w5Dty3EaFi983etw",
-    "STAG": "{{AWS_SECRET}}",
-    "PROD": "{{AWS_SECRET}}"
+    "dev": "w5Dty3EaFi983etw",
+    "stag": "{{AWS_SECRET}}",
+    "prod": "{{AWS_SECRET}}",
+    "isSecret": true
   },
   "DB_CONNECTION_URL": "https://{{ENV}}-service-xyz-{{ENV}}.xyx.{{ENV}}-mongo.com",
   "DB_CONNECTION_PASSWORD": {
-    "DEV": "w5Dty3EaFi983etw",
-    "STAG": "{{DB_PASSWORD}}",
-    "PROD": "{{DB_PASSWORD}}"
+    "dev": "w5Dty3EaFi983etw",
+    "stag": "{{DB_PASSWORD}}",
+    "prod": "{{DB_PASSWORD}}",
+    "isSecret": true
   },
   "ANALYTICS_URL": {
-    "DEV": "https://analytics.dev-services.com/",
-    "STAG": "https://analytics.stag-services.com/",
-    "PROD": "https://analytics.prod-services.com/"
+    "dev": "https://analytics.dev-services.com/",
+    "stag": "https://analytics.stag-services.com/",
+    "prod": "https://analytics.prod-services.com/"
   },
   "CONTACT_US_EMAIL": {
-   "DEFAULT": "hello-{{ENV}}@abcd.com",
-   "PROD": "hello@abcd.com"
- }
+   "default": "hello-{{ENV}}@abcd.com",
+   "prod": "hello@abcd.com"
+  }
 }
 ```
 

--- a/example/index.js
+++ b/example/index.js
@@ -9,7 +9,7 @@ console.log("[Env] ENV: ", process.env.ENV);
 console.log("[Env] BASE_URL: ", process.env.BASE_URL);
 console.log("[Env] ANALYTICS_URL: ", process.env.ANALYTICS_URL);
 
-require('envone').config({ debug: true });
+const configuredEnv = require('envone').config({ debug: true });
 
 console.log("[Updated Env] BFF_URL: ", process.env.BFF_URL);
 console.log("[Updated Env] SALESFORCE_URL: ", process.env.SALESFORCE_URL);
@@ -17,6 +17,8 @@ console.log("[Updated Env] AWS_ACCESS_KEY: ", process.env.AWS_ACCESS_KEY);
 console.log("[Updated Env] DB_CONNECTION_URL: ", process.env.DB_CONNECTION_URL);
 console.log("[Updated Env] ANALYTICS_URL: ", process.env.ANALYTICS_URL);
 console.log("[Updated Env] CONTACT_US_EMAIL: ", process.env.CONTACT_US_EMAIL);
+
+console.log(`[Configured Env] `, configuredEnv);
 
 app.get('/hello', (req, res) =>
   res.send("Hello, Welcome to Express health test server"),

--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
     "envone": "0.3.0"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "start:env": "ENV=DEV ENV_TEXT=dev BASE_URL=https://xyz.test.abcd.com ANALYTICS_URL=https://analytics.services.com/ node index.js"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -110,7 +110,7 @@ function parseEnv(config) {
         logger(`Can't find a valid environment value of "${key}" for ${nodeEnv} environment.`);
       }
     });
-    return config;
+    return { parsed: config };
   } catch (error) {
     logger(`Error : ${error}`);
     return { error };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,81 +45,83 @@ describe("should configure environment variables", () => {
 
   })
 
-
   it("should parse the environment variable", () => {
     const response = envOne.config()
-    expect(response).haveOwnProperty("DB_CONNECTION_URL");
-    expect(response.DB_CONNECTION_URL).is.not.null;
-    expect(response.DB_CONNECTION_URL).is.not.equal(envConfig.DB_CONNECTION_URL);
-    expect(response.DB_CONNECTION_URL).is.equal("https://service-xyz-DEV.xyx.mongo.com");
+    expect(response).haveOwnProperty("parsed");
+    expect(response.parsed).is.not.null;
+    expect(response.parsed).haveOwnProperty("DB_CONNECTION_URL");
+    expect(response.parsed.DB_CONNECTION_URL).is.not.null;
+    expect(response.parsed.DB_CONNECTION_URL).is.not.equal(envConfig.DB_CONNECTION_URL);
+    expect(response.parsed.DB_CONNECTION_URL).is.equal("https://service-xyz-DEV.xyx.mongo.com");
     expect(readFileSyncStub.callCount).is.equal(1);
   })
 
   it("should not change the plain text environment value without any dynamic configurations", () => {
     expect(envConfig.BFF_URL).is.equal("https://www.test-service.com/api/v1")
     const response = envOne.config()
-    expect(response).haveOwnProperty("BFF_URL");
-    expect(response.BFF_URL).is.not.null;
-    expect(response.BFF_URL).is.equal(envConfig.BFF_URL);
+    expect(response).haveOwnProperty("parsed");
+    expect(response.parsed).haveOwnProperty("BFF_URL");
+    expect(response.parsed.BFF_URL).is.not.null;
+    expect(response.parsed.BFF_URL).is.equal(envConfig.BFF_URL);
     expect(readFileSyncStub.callCount).is.equal(1);
   })
 
   it("should pick correct environment variable based on the environment", () => {
     const response = envOne.config()
-    expect(response).haveOwnProperty("TIME_OUT");
+    expect(response.parsed).haveOwnProperty("TIME_OUT");
     expect(mockGetProcessEnv.ENV).is.equal("DEV")
-    expect(response.TIME_OUT).is.not.null;
-    expect(response.TIME_OUT).is.equal(envConfig.TIME_OUT.DEV);
+    expect(response.parsed.TIME_OUT).is.not.null;
+    expect(response.parsed.TIME_OUT).is.equal(envConfig.TIME_OUT.DEV);
   })
 
   it("should pick correct environment variable and replace configurations based on the environment", () => {
     let response = envOne.config()
-    expect(response).haveOwnProperty("DB_CONNECTION_PASSWORD");
+    expect(response.parsed).haveOwnProperty("DB_CONNECTION_PASSWORD");
     expect(mockGetProcessEnv.ENV).is.equal("DEV")
-    expect(response.DB_CONNECTION_PASSWORD).is.not.null;
-    expect(response.DB_CONNECTION_PASSWORD).is.equal(envConfig.DB_CONNECTION_PASSWORD.DEV);
+    expect(response.parsed.DB_CONNECTION_PASSWORD).is.not.null;
+    expect(response.parsed.DB_CONNECTION_PASSWORD).is.equal(envConfig.DB_CONNECTION_PASSWORD.DEV);
 
     mockGetProcessEnv = { ENV: "PROD" }
     getProcessEnvStub.restore(); // restore already wrapped function
     getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
     response = envOne.config()
-    expect(response).haveOwnProperty("DB_CONNECTION_PASSWORD");
+    expect(response.parsed).haveOwnProperty("DB_CONNECTION_PASSWORD");
     expect(mockGetProcessEnv.ENV).is.equal("PROD")
-    expect(response.DB_CONNECTION_PASSWORD).is.not.null;
-    expect(response.DB_CONNECTION_PASSWORD).is.not.equal(envConfig.DB_CONNECTION_PASSWORD.PROD);
-    expect(response.DB_CONNECTION_PASSWORD).is.equal("undefined");
+    expect(response.parsed.DB_CONNECTION_PASSWORD).is.not.null;
+    expect(response.parsed.DB_CONNECTION_PASSWORD).is.not.equal(envConfig.DB_CONNECTION_PASSWORD.PROD);
+    expect(response.parsed.DB_CONNECTION_PASSWORD).is.equal("undefined");
 
     mockGetProcessEnv = { ENV: "PROD", DB_PASSWORD: "12345" }
     getProcessEnvStub.restore(); // restore already wrapped function
     getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
     response = envOne.config()
-    expect(response).haveOwnProperty("DB_CONNECTION_PASSWORD");
+    expect(response.parsed).haveOwnProperty("DB_CONNECTION_PASSWORD");
     expect(mockGetProcessEnv.ENV).is.equal("PROD")
     expect(response.DB_CONNECTION_PASSWORD).is.not.null;
-    expect(response.DB_CONNECTION_PASSWORD).is.not.equal(envConfig.DB_CONNECTION_PASSWORD.PROD);
-    expect(response.DB_CONNECTION_PASSWORD).is.not.equal("undefined");
-    expect(response.DB_CONNECTION_PASSWORD).is.equal("12345");
+    expect(response.parsed.DB_CONNECTION_PASSWORD).is.not.equal(envConfig.DB_CONNECTION_PASSWORD.PROD);
+    expect(response.parsed.DB_CONNECTION_PASSWORD).is.not.equal("undefined");
+    expect(response.parsed.DB_CONNECTION_PASSWORD).is.equal("12345");
     getProcessEnvStub.restore();
   })
 
   it("should replace multiple configurations in single environnement variable", () => {
     let response = envOne.config()
-    expect(response).haveOwnProperty("ANALYTICS_URL");
+    expect(response.parsed).haveOwnProperty("ANALYTICS_URL");
     expect(mockGetProcessEnv.ENV).is.equal("DEV")
-    expect(response.ANALYTICS_URL).is.not.null;
-    expect(response.ANALYTICS_URL).is.equal("https://DEV-analytics.undefined-albc.com");
+    expect(response.parsed.ANALYTICS_URL).is.not.null;
+    expect(response.parsed.ANALYTICS_URL).is.equal("https://DEV-analytics.undefined-albc.com");
 
     mockGetProcessEnv = { ENV: "PROD", SYSTEM: "rmt" }
     getProcessEnvStub.restore(); // restore already wrapped function
     getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
     response = envOne.config()
-    expect(response).haveOwnProperty("ANALYTICS_URL");
+    expect(response.parsed).haveOwnProperty("ANALYTICS_URL");
     expect(mockGetProcessEnv.ENV).is.equal("PROD")
     expect(mockGetProcessEnv.SYSTEM).is.equal("rmt")
-    expect(response.ANALYTICS_URL).is.not.null;
-    expect(response.ANALYTICS_URL).is.not.equal("https://DEV-analytics.undefined-albc.com");
-    expect(response.ANALYTICS_URL).is.not.equal("https://PROD-analytics.undefined-albc.com");
-    expect(response.ANALYTICS_URL).is.equal("https://PROD-analytics.rmt-albc.com");
+    expect(response.parsed.ANALYTICS_URL).is.not.null;
+    expect(response.parsed.ANALYTICS_URL).is.not.equal("https://DEV-analytics.undefined-albc.com");
+    expect(response.parsed.ANALYTICS_URL).is.not.equal("https://PROD-analytics.undefined-albc.com");
+    expect(response.parsed.ANALYTICS_URL).is.equal("https://PROD-analytics.rmt-albc.com");
     getProcessEnvStub.restore();
   })
 
@@ -128,22 +130,22 @@ describe("should configure environment variables", () => {
     getProcessEnvStub.restore(); // restore already wrapped function
     getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
     let response = envOne.config()
-    expect(response).haveOwnProperty("LOG_URL");
+    expect(response.parsed).haveOwnProperty("LOG_URL");
     expect(mockGetProcessEnv.ENV).is.undefined;
-    expect(response.LOG_URL).is.not.null;
-    expect(response.LOG_URL).is.equal("https://undefined-abc.undefined-service.log-man.com");
+    expect(response.parsed.LOG_URL).is.not.null;
+    expect(response.parsed.LOG_URL).is.equal("https://undefined-abc.undefined-service.log-man.com");
 
     mockGetProcessEnv = { ENV: "PROD" }
     getProcessEnvStub.restore(); // restore already wrapped function
     getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
     response = envOne.config()
-    expect(response).haveOwnProperty("LOG_URL");
+    expect(response.parsed).haveOwnProperty("LOG_URL");
     expect(mockGetProcessEnv.ENV).is.equal("PROD")
-    expect(response.LOG_URL).is.not.null;
-    expect(response.LOG_URL).is.not.equal("https://undefined-abc.undefined-service.log-man.com");
-    expect(response.LOG_URL).is.not.equal("https://PROD-abc.undefined-service.log-man.com");
-    expect(response.LOG_URL).is.not.equal("https://undefined-abc.PROD-service.log-man.com");
-    expect(response.LOG_URL).is.equal("https://PROD-abc.PROD-service.log-man.com");
+    expect(response.parsed.LOG_URL).is.not.null;
+    expect(response.parsed.LOG_URL).is.not.equal("https://undefined-abc.undefined-service.log-man.com");
+    expect(response.parsed.LOG_URL).is.not.equal("https://PROD-abc.undefined-service.log-man.com");
+    expect(response.parsed.LOG_URL).is.not.equal("https://undefined-abc.PROD-service.log-man.com");
+    expect(response.parsed.LOG_URL).is.equal("https://PROD-abc.PROD-service.log-man.com");
     getProcessEnvStub.restore();
   })
 
@@ -167,39 +169,39 @@ describe("should configure environment variables", () => {
 
   it("should pick the DEFAULT for un-defined environment configurations", () => {
     let response = envOne.config()
-    expect(response).haveOwnProperty("CONTACT_US_EMAIL");
+    expect(response.parsed).haveOwnProperty("CONTACT_US_EMAIL");
     expect(mockGetProcessEnv.ENV).is.equal("DEV")
-    expect(response.CONTACT_US_EMAIL).is.not.null;
-    expect(response.CONTACT_US_EMAIL).is.equal("hello-DEV@abcd.com");
+    expect(response.parsed.CONTACT_US_EMAIL).is.not.null;
+    expect(response.parsed.CONTACT_US_EMAIL).is.equal("hello-DEV@abcd.com");
 
     mockGetProcessEnv = { ENV: "STAG" }
     getProcessEnvStub.restore(); // restore already wrapped function
     getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
     response = envOne.config()
-    expect(response).haveOwnProperty("CONTACT_US_EMAIL");
+    expect(response.parsed).haveOwnProperty("CONTACT_US_EMAIL");
     expect(mockGetProcessEnv.ENV).is.equal("STAG")
-    expect(response.CONTACT_US_EMAIL).is.not.null;
-    expect(response.CONTACT_US_EMAIL).is.equal("hello-STAG@abcd.com");
+    expect(response.parsed.CONTACT_US_EMAIL).is.not.null;
+    expect(response.parsed.CONTACT_US_EMAIL).is.equal("hello-STAG@abcd.com");
 
     mockGetProcessEnv = { ENV: "PROD" }
     getProcessEnvStub.restore(); // restore already wrapped function
     getProcessEnvStub = sinon.stub(envOne, "retrieveProcessEnv").returns(mockGetProcessEnv);
     response = envOne.config()
-    expect(response).haveOwnProperty("CONTACT_US_EMAIL");
+    expect(response.parsed).haveOwnProperty("CONTACT_US_EMAIL");
     expect(mockGetProcessEnv.ENV).is.equal("PROD")
-    expect(response.CONTACT_US_EMAIL).is.not.null;
-    expect(response.CONTACT_US_EMAIL).is.not.equal("hello-PROD@abcd.com");
-    expect(response.CONTACT_US_EMAIL).is.equal("hello@abcd.com");
+    expect(response.parsed.CONTACT_US_EMAIL).is.not.null;
+    expect(response.parsed.CONTACT_US_EMAIL).is.not.equal("hello-PROD@abcd.com");
+    expect(response.parsed.CONTACT_US_EMAIL).is.equal("hello@abcd.com");
     getProcessEnvStub.restore();
   })
 
   it("should have error object if regex matcher throws any errors", () => {
     const matcherStub = sinon.stub(envOne, "matcher").throws(new Error("An error occurred"));
     let response = envOne.config()
-    expect(response).haveOwnProperty("BFF_URL");
-    expect(response.BFF_URL).is.not.null;
-    expect(response.BFF_URL).haveOwnProperty("error");
-    expect(response.BFF_URL.error).is.not.null;
+    expect(response.parsed).haveOwnProperty("BFF_URL");
+    expect(response.parsed.BFF_URL).is.not.null;
+    expect(response.parsed.BFF_URL).haveOwnProperty("error");
+    expect(response.parsed.BFF_URL.error).is.not.null;
     matcherStub.restore();
   })
 
@@ -239,13 +241,13 @@ describe("should configure environment variables", () => {
 
   it("should not expose secretEnvironmentKeys, if envConfig doesn't have any secrets", () => {
     let response = envOne.config()
-    expect(response).not.haveOwnProperty("SECRET_ENVIRONMENT_KEYS");
+    expect(response.parsed).not.haveOwnProperty("SECRET_ENVIRONMENT_KEYS");
 
     readFileSyncStub.restore();
     envConfig.DB_CONNECTION_PASSWORD.isSecret = false;
     readFileSyncStub = sinon.stub(fs, 'readFileSync').returns(JSON.stringify(envConfig))
     response = envOne.config()
-    expect(response).not.haveOwnProperty("SECRET_ENVIRONMENT_KEYS");
+    expect(response.parsed).not.haveOwnProperty("SECRET_ENVIRONMENT_KEYS");
     readFileSyncStub.restore();
   })
 });


### PR DESCRIPTION
Add `parsed` key in the response format,

```
{ parsed: 
   { BFF_URL: 'undefined/api/v1',
     SALESFORCE_URL: 'https://dev-salesforce.com/v1/test',
     AWS_ACCESS_KEY: 'w5Dty3EaFi983etw',
     AWS_ACCESS_SECRET: 'w5Dty3EaFi983etw',
     DB_CONNECTION_URL: 'https://dev-service-xyz-dev.xyx.dev-mongo.com',
     DB_CONNECTION_PASSWORD: 'w5Dty3EaFi983etw',
     ANALYTICS_URL: 'https://analytics.dev-services.com/',
     CONTACT_US_EMAIL: 'hello-dev@abcd.com' },
  SECRET_ENVIRONMENT_KEYS: [ 'DB_CONNECTION_PASSWORD' ]
}
```