### PR TITLE
Implement Required keys feature 

### DIFF
--- a/example/.env.config
+++ b/example/.env.config
@@ -1,31 +1,35 @@
 {
   "BFF_URL": "{{BASE_URL}}/api/v1",
-  "SALESFORCE_URL":"https://{{ENV}}-salesforce.com/v1/test",
+  "SALESFORCE_URL":"https://{{ENV_TEXT}}-salesforce.com/v1/test",
   "AWS_ACCESS_KEY": {
-    "dev": "w5Dty3EaFi983etw",
-    "stag": "u7Awda72Sd2Wfaf",
-    "prod": "{{AWS_KEY}}"
+    "DEV": "w5Dty3EaFi983etw",
+    "STAG": "u7Awda72Sd2Wfaf",
+    "PROD": "{{AWS_KEY}}"
   },
   "AWS_ACCESS_SECRET": {
-    "dev": "w5Dty3EaFi983etw",
-    "stag": "{{AWS_SECRET}}",
-    "prod": "{{AWS_SECRET}}",
+    "DEV": "w5Dty3EaFi983etw",
+    "STAG": "{{AWS_SECRET}}",
+    "PROD": "{{AWS_SECRET}}",
     "isSecret": true
   },
-  "DB_CONNECTION_URL": "https://{{ENV}}-service-xyz-{{ENV}}.xyx.{{ENV}}-mongo.com",
+  "DB_CONNECTION_URL": "https://{{ENV_TEXT}}-service-xyz-{{ENV_TEXT}}.xyx.{{ENV_TEXT}}-mongo.com",
   "DB_CONNECTION_PASSWORD": {
-    "dev": "w5Dty3EaFi983etw",
-    "stag": "{{DB_PASSWORD}}",
-    "prod": "{{DB_PASSWORD}}",
+    "DEV": "w5Dty3EaFi983etw",
+    "STAG": "{{DB_PASSWORD}}",
+    "PROD": "{{DB_PASSWORD}}",
     "isSecret": true
   },
   "ANALYTICS_URL": {
-    "dev": "https://analytics.dev-services.com/",
-    "stag": "https://analytics.stag-services.com/",
-    "prod": "https://analytics.prod-services.com/"
+    "DEV": "https://analytics.dev-services.com/",
+    "STAG": "https://analytics.stag-services.com/",
+    "PROD": "https://analytics.prod-services.com/"
   },
   "CONTACT_US_EMAIL": {
-   "default": "hello-{{ENV}}@abcd.com",
-   "prod": "hello@abcd.com"
+   "default": "hello-{{ENV_TEXT}}@abcd.com",
+   "PROD": "hello@abcd.com"
+  },
+  "S3_PATH": {
+    "default": "{{S3_PATH}}",
+    "isRequired": true
   }
 }

--- a/src/RequiredEnvMissingError.js
+++ b/src/RequiredEnvMissingError.js
@@ -1,0 +1,14 @@
+
+/**
+ * Required Environment Keys missing Error
+ */
+class RequiredEnvMissingError extends Error {
+  constructor(message, key) {
+    super(message);
+    this.isRequiredEnvMissingError = true; 
+    this.key = key;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+module.exports = RequiredEnvMissingError;

--- a/test/.env.config
+++ b/test/.env.config
@@ -16,5 +16,8 @@
   "CONTACT_US_EMAIL": {
    "DEFAULT": "hello-{{ENV}}@abcd.com",
    "PROD": "hello@abcd.com"
+  },
+  "APP_SECRET" : {
+    "DEFAULT": "{{APP_SECRET_V_1_9}}"
   }
 }


### PR DESCRIPTION
Provides an extended feature to indicate the required environment keys to the server. It will prevent from starting the server without the proper environment keys.

Feature Request : #11 

```
{ 
   "S3_PATH": {
      "default": "{{S3_PATH}}",
      "isRequired": true
    }
}
```