### PR TITLE
Adding comment parser to config parsing

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -133,6 +133,14 @@ function parseEnv(config) {
 }
 
 /**
+ * Parse the JSON content to remove comments
+ * @param {*} content
+ */
+function parseReadFile(content) {
+  return content.replace(/^\s*\/\/.*$\n/gm, '')
+}
+
+/**
  * Configure the environment variables
  */
 module.exports.config = function (options) {
@@ -148,7 +156,7 @@ module.exports.config = function (options) {
   }
 
   try {
-    const parsedData = parseEnv(JSON.parse(fs.readFileSync(configPath, { encoding: "utf8" })));
+    const parsedData = parseEnv(JSON.parse(parseReadFile(fs.readFileSync(configPath, { encoding: "utf8" }))));
 
     if (Object.keys(providedEnvironmentConfigs).length > 0) {
       parsedData.provided = providedEnvironmentConfigs;


### PR DESCRIPTION
Adding a parser to allow comments in the JSON and strip them out.

Provides an initial fix for issue #12 .

This could be improved with additional support for multiline comments and comments after a config value. Currently this just supports single inline comments where the entire line is commented out as in this case:

```
{
  "HOST": "https://abc.com",
  // "SERVER_URL": "{{BASE_URL}}/api/v1",
}
```